### PR TITLE
Typo in the command `cmd.sh up`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [docs] https://horoiwa.github.io/ProjectBoilerPlate/
 
 
-- Build image and up container: `/cmd.sh up`
+- Build image and up container: `./cmd.sh up`
 
 - login to the container: `./cmd.sh login`
 


### PR DESCRIPTION
Exactly the same as the title 